### PR TITLE
fix(hooks): robustify git-commit-format-check parsing

### DIFF
--- a/.claude/hooks/git-commit-format-check.sh
+++ b/.claude/hooks/git-commit-format-check.sh
@@ -1,18 +1,59 @@
 #!/usr/bin/env bash
 # Enforces header-only commit messages: "type(scope): summary", max 100 chars,
 # no body, no Co-Authored-By trailer, for `git commit -m ...` (including the
-# heredoc style `-m "$(cat <<'EOF' ...)"`).
+# heredoc style `-m "$(cat <<'EOF' ...)"`, any delimiter).
+#
+# This is text-based parsing of a raw shell command string, not a real shell
+# parser. It targets the realistic patterns Claude Code produces for its own
+# commits, not adversarial shell escaping.
 set -euo pipefail
+
+# Extracts every `-m "..."` / `-m '...'` argument (each becomes a paragraph,
+# joined by a blank line, matching how git concatenates multiple -m flags).
+# Matches the closing quote to the SAME type as the opening one, so a message
+# quoted with " can safely contain a ' (e.g. "fix: it's broken") and vice versa.
+extract_dash_m_messages() {
+    local remaining="$1"
+    local re="-m[[:space:]]+(\"([^\"]*)\"|'([^']*)')"
+    while [[ "$remaining" =~ $re ]]; do
+        if [ "${BASH_REMATCH[1]:0:1}" = '"' ]; then
+            printf '%s\n\n' "${BASH_REMATCH[2]}"
+        else
+            printf '%s\n\n' "${BASH_REMATCH[3]}"
+        fi
+        remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+    done
+}
 
 cmd=$(jq -r '.tool_input.command // empty')
 
-printf '%s' "$cmd" | grep -qE '(^|[;&|]) *git commit\b.*-m' || exit 0
+commit_regex='(^|[;&|]) *git commit\b'
+printf '%s' "$cmd" | grep -qE "${commit_regex}.*-m" || exit 0
 
-if printf '%s' "$cmd" | grep -qE "<<[\"']*EOF[\"']*"; then
-    start_line=$(printf '%s\n' "$cmd" | grep -nE "<<[\"']*EOF[\"']*" | head -1 | cut -d: -f1)
-    full_message=$(printf '%s\n' "$cmd" | tail -n +"$((start_line + 1))" | sed '/^EOF$/,$d')
+# Heuristic against false positives when "git commit" appears inside a string
+# literal (e.g. `echo "...; git commit -m..."`): if an odd number of quote
+# characters precede the match, we're still inside an open quote at that
+# point, so this isn't a real invocation - let it through unchecked.
+first_match=$(printf '%s' "$cmd" | grep -oE "$commit_regex" | head -1)
+prefix="${cmd%%"$first_match"*}"
+quote_count=$(printf '%s' "$prefix" | { grep -o "['\"]" || true; } | wc -l | tr -d ' ')
+[ $((quote_count % 2)) -eq 0 ] || exit 0
+
+heredoc_re="(<<-?)[\"']?([A-Za-z_][A-Za-z0-9_]*)[\"']?"
+if [[ "$cmd" =~ $heredoc_re ]]; then
+    operator="${BASH_REMATCH[1]}"
+    delimiter="${BASH_REMATCH[2]}"
+    start_line=$(printf '%s\n' "$cmd" | grep -nE -- "${operator}[\"']?${delimiter}[\"']?" | head -1 | cut -d: -f1)
+    if [ "$operator" = "<<-" ]; then
+        # <<- strips leading tabs from both the end delimiter and every content line.
+        end_pattern="^[[:space:]]*${delimiter}[[:space:]]*$"
+        full_message=$(printf '%s\n' "$cmd" | tail -n +"$((start_line + 1))" | sed -n "/${end_pattern}/q;p" | sed 's/^\t*//')
+    else
+        end_pattern="^${delimiter}[[:space:]]*$"
+        full_message=$(printf '%s\n' "$cmd" | tail -n +"$((start_line + 1))" | sed -n "/${end_pattern}/q;p")
+    fi
 else
-    full_message=$(printf '%s\n' "$cmd" | grep -oE -- "-m[[:space:]]+['\"][^'\"]*" | head -1 | sed -E "s/-m[[:space:]]+['\"]//")
+    full_message=$(extract_dash_m_messages "$cmd")
 fi
 
 [ -z "$full_message" ] && exit 0

--- a/.claude/hooks/git-commit-format-check.test.sh
+++ b/.claude/hooks/git-commit-format-check.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Test suite for git-commit-format-check.sh. Run directly: ./git-commit-format-check.test.sh
+set -uo pipefail
+
+hook_dir="$(cd "$(dirname "$0")" && pwd)"
+hook="$hook_dir/git-commit-format-check.sh"
+pass=0
+fail=0
+
+run_case() {
+    local name="$1" expected="$2" command="$3"
+    local payload output actual
+    payload=$(jq -n --arg cmd "$command" '{tool_input:{command:$cmd}}')
+    output=$(printf '%s' "$payload" | bash "$hook")
+    actual="allow"
+    printf '%s' "$output" | grep -q '"permissionDecision":"deny"' && actual="deny"
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS: $name"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $name (expected $expected, got $actual) -- output: $output"
+        fail=$((fail + 1))
+    fi
+}
+
+run_case "apostrophe in double-quoted message" "allow" \
+    'git commit -m "fix(core): it'"'"'s broken"'
+
+run_case "double-quote inside single-quoted message" "allow" \
+    "git commit -m 'fix(core): say \"hi\" properly'"
+
+run_case "multiple -m flags produce a body" "deny" \
+    'git commit -m "fix(core): title here" -m "a real body line"'
+
+command=$(cat <<'RAWCMD'
+git commit -m "$(cat <<'EOF'
+feat(core): add thing
+EOF
+)"
+RAWCMD
+)
+run_case "heredoc with EOF delimiter" "allow" "$command"
+
+command=$(cat <<'RAWCMD'
+git commit -m "$(cat <<'MSG'
+feat(core): add thing
+MSG
+)"
+RAWCMD
+)
+run_case "heredoc with custom delimiter" "allow" "$command"
+
+command=$(printf 'git commit -m "$(cat <<-'"'"'COMMIT'"'"'\n\tfeat(core): add thing\n\tCOMMIT\n)"')
+run_case "heredoc <<- strips leading tabs" "allow" "$command"
+
+run_case "git commit text inside an unrelated echo string" "allow" \
+    'echo "just talking about; git commit -m stuff"'
+
+run_case "chained command before a real commit" "allow" \
+    'npm test && git commit -m "fix(core): after tests"'
+
+run_case "valid header-only commit" "allow" \
+    'git commit -m "fix(core): simple valid header"'
+
+run_case "header missing scope" "deny" \
+    'git commit -m "update stuff"'
+
+long_header="fix(core): $(printf 'x%.0s' $(seq 1 95))"
+run_case "header over 100 chars" "deny" \
+    "git commit -m \"$long_header\""
+
+command=$(cat <<'RAWCMD'
+git commit -m "$(cat <<'EOF'
+feat(core): add thing
+
+with a body line
+EOF
+)"
+RAWCMD
+)
+run_case "heredoc with a real body" "deny" "$command"
+
+command=$(cat <<'RAWCMD'
+git commit -m "$(cat <<'EOF'
+feat(core): add thing
+
+Co-Authored-By: Bob <bob@example.com>
+EOF
+)"
+RAWCMD
+)
+run_case "heredoc with Co-Authored-By trailer" "deny" "$command"
+
+run_case "git commit without -m" "allow" \
+    'git commit --amend'
+
+run_case "unrelated command" "allow" \
+    'ls -la'
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,21 +7,11 @@
           {
             "type": "command",
             "command": "bash '/Users/matthieuelie/.claude/hooks/pr-body-no-test-plan.sh'"
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
+          },
           {
             "type": "command",
             "command": "bash '/Users/matthieuelie/.claude/hooks/git-commit-format-check.sh'"
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
+          },
           {
             "type": "command",
             "command": "bash '/Users/matthieuelie/.claude/hooks/block-main-branch-commits.sh'"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .zshrc.d/env.zsh
 .config/tmux/plugins
+.planning/


### PR DESCRIPTION
## Summary
- Fixes message extraction in the git-commit-format-check hook: apostrophes/quotes no longer truncate the message, multiple -m flags are now detected as a body, and heredocs with any delimiter (including <<-) are recognized.
- Adds a quote-parity heuristic so a commit-shaped mention appearing inside an unrelated echo command's string argument is no longer treated as a real invocation.
- Adds git-commit-format-check.test.sh, a dependency-free bash test suite covering these cases (15 cases, all passing).
- Merges the 3 separate PreToolUse/Bash matcher blocks in settings.json into one block with 3 hooks (no behavior change).