### PR TITLE
feat(claude): block branch creation with non-conventional names

### DIFF
--- a/.claude/agents/backlog-builder.md
+++ b/.claude/agents/backlog-builder.md
@@ -21,7 +21,7 @@ For each epic, produce a file `.planning/EPIC-<slug>.md` following the template 
 
 ### 2. Produce the global manifest
 
-Write/update `outputs/handoff-manifest.md`:
+Write/update `.planning/handoff-manifest.md`:
 
 ```
 | Story | Epic | Points | Status | Dependencies |

--- a/.claude/agents/backlog-builder.md
+++ b/.claude/agents/backlog-builder.md
@@ -17,7 +17,7 @@ You receive a raw markdown file handwritten by the user: a list of things to do,
 
 The plan is always broken down into multiple stories (no "single story" case: if the plan looks atomic, still look for a distinct sub-step to isolate).
 
-For each epic, produce a file `outputs/EPIC-XX-<slug>.md` following the template at `~/dot/.claude/agents/epic-story-template.md`.
+For each epic, produce a file `.planning/EPIC-<slug>.md` following the template at `~/dot/.claude/agents/epic-story-template.md`. The slug names the epic after what it's about (e.g. `user-authentication`), not a running number.
 
 ### 2. Produce the global manifest
 
@@ -26,7 +26,7 @@ Write/update `outputs/handoff-manifest.md`:
 ```
 | Story | Epic | Points | Status | Dependencies |
 |-------|------|--------|--------|--------------|
-| STORY-01-01 | EPIC-01 | 3 | ready-for-test | none |
+| STORY-user-authentication-01 | EPIC-user-authentication | 3 | ready-for-test | none |
 ```
 
 ## Strict rules

--- a/.claude/agents/epic-story-template.md
+++ b/.claude/agents/epic-story-template.md
@@ -1,13 +1,13 @@
 ---
-epic: EPIC-01
+epic: EPIC-<slug>
 title: [short name]
 points_total: [sum]
 ---
 
-## STORY-01-01: [short title]
+## STORY-<slug>-01: [short title]
 **Points (PO proposal)**: [Fibonacci: 1,2,3,5,8 — if >3, split further]
 **Files/domains involved**: [explicit list, must be disjoint from other stories in the same batch]
-**Dependencies**: [STORY-XX-XX or "none"]
+**Dependencies**: [STORY-<slug>-XX or "none"]
 
 **As a** [role]
 **I want** [action]

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -9,7 +9,7 @@ You are the Tech Lead agent for this project.
 
 ## Input
 
-You receive the stories produced by the Product Owner agent (`outputs/EPIC-<slug>.md`) and the manifest (`outputs/handoff-manifest.md`).
+You receive the stories produced by the Product Owner agent (`.planning/EPIC-<slug>.md`) and the manifest (`.planning/handoff-manifest.md`).
 
 ## Expected output
 

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -9,7 +9,7 @@ You are the Tech Lead agent for this project.
 
 ## Input
 
-You receive the stories produced by the Product Owner agent (`outputs/EPIC-XX-<slug>.md`) and the manifest (`outputs/handoff-manifest.md`).
+You receive the stories produced by the Product Owner agent (`outputs/EPIC-<slug>.md`) and the manifest (`outputs/handoff-manifest.md`).
 
 ## Expected output
 

--- a/.claude/hooks/block-bad-branch-name.sh
+++ b/.claude/hooks/block-bad-branch-name.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Blocks branch creation whose name doesn't match <type>/<description>
+# (feat|fix|chore|docs|refactor|test|style|perf|build|ci|revert), for
+# `git checkout -b`, `git switch -c`, and `git branch <name>`.
+#
+# Text-based parsing of a raw shell command string, not a real shell parser.
+# Targets the realistic patterns Claude Code produces for its own branch
+# creation, not adversarial shell escaping.
+set -euo pipefail
+
+cmd=$(jq -r '.tool_input.command // empty')
+pattern='^(feat|fix|chore|docs|refactor|test|style|perf|build|ci|revert)/[a-zA-Z0-9._-]+$'
+
+name=""
+if [[ "$cmd" =~ git[[:space:]]+checkout[[:space:]]+-[bB][[:space:]]+([^[:space:]]+) ]]; then
+    name="${BASH_REMATCH[1]}"
+elif [[ "$cmd" =~ git[[:space:]]+switch[[:space:]]+-[cC][[:space:]]+([^[:space:]]+) ]]; then
+    name="${BASH_REMATCH[1]}"
+elif [[ "$cmd" =~ git[[:space:]]+branch[[:space:]]+([^-[:space:]][^[:space:]]*) ]]; then
+    name="${BASH_REMATCH[1]}"
+fi
+
+[ -z "$name" ] && exit 0
+[[ "$name" =~ $pattern ]] && exit 0
+
+jq -cn --arg reason "Blocked: branch name '$name' doesn't match <type>/<description> (feat|fix|chore|docs|refactor|test|style|perf|build|ci|revert)." \
+    '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -100,6 +100,10 @@
           {
             "type": "command",
             "command": "bash \"$HOME/.claude/hooks/block-main-branch-commits.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/block-bad-branch-name.sh\""
           }
         ]
       },


### PR DESCRIPTION
## Summary
- New `.claude/hooks/block-bad-branch-name.sh`, wired into `PreToolUse` for `Bash` in `.claude/settings.json`
- Blocks (deny) `git checkout -b`, `git switch -c`, and `git branch <name>` when Claude Code creates a branch whose name doesn't match `<type>/<description>` (feat|fix|chore|docs|refactor|test|style|perf|build|ci|revert)
- Scoped to Claude Code's own Bash tool calls only — manual `git` usage in a terminal is unaffected